### PR TITLE
chore: upgrade gravitee BOM from 1.1 to 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <name>Gravitee.io - Tracing - Jaeger</name>
 
     <properties>
-        <gravitee-bom.version>1.1</gravitee-bom.version>
+        <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-node-api.version>1.16.0</gravitee-node-api.version>
         <grpc-netty.version>1.38.1</grpc-netty.version>
         <opentelemetry-exporter-jaeger.version>1.3.0</opentelemetry-exporter-jaeger.version>


### PR DESCRIPTION
With BOM version 1.1, installing the plugin and enabling tracing leads
to `NoSuchMethodError` on `io.vertx.core.Context` on calls which translate
to client timeouts.

see https://github.com/gravitee-io/issues/issues/6366