### PR TITLE
feat(tracing): add hook mechanism to deal with tracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/java/io/gravitee/tracer/jaeger/JaegerSpan.java
+++ b/src/main/java/io/gravitee/tracer/jaeger/JaegerSpan.java
@@ -17,6 +17,7 @@ package io.gravitee.tracer.jaeger;
 
 import io.gravitee.tracing.api.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -25,9 +26,11 @@ import io.opentelemetry.api.trace.StatusCode;
 public class JaegerSpan implements Span {
 
     private final io.opentelemetry.api.trace.Span span;
+    private final Scope scope;
 
-    public JaegerSpan(final io.opentelemetry.api.trace.Span span) {
+    public JaegerSpan(final io.opentelemetry.api.trace.Span span, Scope scope) {
         this.span = span;
+        this.scope = scope;
     }
 
     @Override
@@ -64,5 +67,6 @@ public class JaegerSpan implements Span {
     @Override
     public void end() {
         span.end();
+        scope.close();
     }
 }

--- a/src/main/java/io/gravitee/tracer/jaeger/VertxContextStorageProvider.java
+++ b/src/main/java/io/gravitee/tracer/jaeger/VertxContextStorageProvider.java
@@ -56,10 +56,25 @@ public class VertxContextStorageProvider implements ContextStorageProvider {
         @Override
         public Context current() {
             io.vertx.core.Context vertxCtx = Vertx.currentContext();
+            return current(vertxCtx);
+        }
+
+        public Context current(io.vertx.core.Context vertxCtx) {
             if (vertxCtx == null) {
                 return null;
             }
             return vertxCtx.getLocal(ACTIVE_CONTEXT);
+        }
+
+        public void clear() {
+            io.vertx.core.Context vertxCtx = Vertx.currentContext();
+            clear(vertxCtx);
+        }
+
+        public void clear(io.vertx.core.Context vertxCtx) {
+            if (vertxCtx != null) {
+                vertxCtx.removeLocal(ACTIVE_CONTEXT);
+            }
         }
     }
 }

--- a/src/main/resources/META-INF/io.opentelemetry.context.ContextStorageProvider
+++ b/src/main/resources/META-INF/io.opentelemetry.context.ContextStorageProvider
@@ -1,0 +1,1 @@
+io.gravitee.tracer.jaeger.VertxContextStorageProvider


### PR DESCRIPTION
**Description**

Fix some issues with the vertx tracer and how span are creating. This has been done during tracing migration for jupiter.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-prototype-reactive-tracing-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/tracer/gravitee-tracer-jaeger/1.2.0-prototype-reactive-tracing-SNAPSHOT/gravitee-tracer-jaeger-1.2.0-prototype-reactive-tracing-SNAPSHOT.zip)
  <!-- Version placeholder end -->
