### PR TITLE
chore: upgrade jaeger dependency and bump gravitee bom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@2.5.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Issue**
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/XXXXX
 
 **Description**
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,50 @@
 {
   "extends": [
     "config:base",
-    "schedule:earlyMondays"
+    ":label(dependencies)"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchDatasources": [
+        "orb"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": [
+        "provided",
+        "test",
+        "build",
+        "import",
+        "parent"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": [
+        "provided",
+        "test",
+        "build",
+        "import",
+        "parent"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <name>Gravitee.io - Tracing - Jaeger</name>
 
     <properties>
-        <gravitee-bom.version>2.0</gravitee-bom.version>
-        <gravitee-node-api.version>1.20.0</gravitee-node-api.version>
-        <grpc-netty.version>1.38.1</grpc-netty.version>
-        <opentelemetry-exporter-jaeger.version>1.3.0</opentelemetry-exporter-jaeger.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-node-api.version>3.0.3</gravitee-node-api.version>
+        <grpc-netty.version>1.54.0</grpc-netty.version>
+        <opentelemetry-exporter-jaeger.version>1.25.0</opentelemetry-exporter-jaeger.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/tracers</publish-folder-path>
     </properties>
@@ -51,6 +51,13 @@
                 <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry-exporter-jaeger.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -83,13 +90,22 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
-            <version>${opentelemetry-exporter-jaeger.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
+            <version>${grpc-netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
             <version>${grpc-netty.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.tracer</groupId>
@@ -38,6 +38,12 @@
         <gravitee-node-api.version>3.0.3</gravitee-node-api.version>
         <grpc-netty.version>1.54.0</grpc-netty.version>
         <opentelemetry-exporter-jaeger.version>1.25.0</opentelemetry-exporter-jaeger.version>
+
+        <maven-plugin-assembly.version>3.5.0</maven-plugin-assembly.version>
+        <maven-plugin-javadoc.version>3.5.0</maven-plugin-javadoc.version>
+        <maven-plugin-prettier.version>0.19</maven-plugin-prettier.version>
+        <maven-plugin-prettier.prettierjava.version>2.0.0</maven-plugin-prettier.prettierjava.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/tracers</publish-folder-path>
     </properties>
@@ -120,7 +126,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -140,10 +146,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>${maven-plugin-prettier.version}</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>${maven-plugin-prettier.prettierjava.version}</prettierJavaVersion>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
BREAKING CHANGE: the gravitee bom has been upgraded to v4.0.0 and gravitee-node-api to 3.0.3, that comes with an upgrade of vertx from v4.1.x to 4.3.8

fixes APIM-1473

### Additional Info

Tested without security. Need to be tested using SSL layer before merging
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-chore-jeager-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/tracer/gravitee-tracer-jaeger/2.0.0-chore-jeager-upgrade-SNAPSHOT/gravitee-tracer-jaeger-2.0.0-chore-jeager-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
