### PR TITLE
fix: upgrade transitive dependency okio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
     <properties>
         <gravitee-bom.version>6.0.32</gravitee-bom.version>
         <gravitee-node-api.version>4.8.2</gravitee-node-api.version>
-        <opentelemetry-exporter-jaeger.version>1.28.0</opentelemetry-exporter-jaeger.version>
+        <opentelemetry-bom.version>1.28.0</opentelemetry-bom.version>
+        <okio.version>3.4.0</okio.version>
         <awaitility.version>4.2.0</awaitility.version>
         <testcontainers.version>1.19.5</testcontainers.version>
 
@@ -60,7 +61,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>${opentelemetry-exporter-jaeger.version}</version>
+                <version>${opentelemetry-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -112,7 +113,11 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>${okio.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
**Description**

Poor upgrade to make Snyk happy. We will need to deprecate this tracer because Jaeger is deprecated in favor of OTP

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
